### PR TITLE
Fixed calling $yoimg_search_providers when it isn't exists.

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -125,15 +125,17 @@ if ( ! class_exists( 'YoImagesSettingsPage' ) ) {
 		public function print_search_options_section_info() {
 			global $yoimg_search_providers;
 			print __('Free stock images search settings.<br/>Please note that searches are performed in english therefore use english search terms.', YOIMG_DOMAIN );
-			print '<br /><br />';
-			print __('Images sources:', YOIMG_DOMAIN );
-			print '<ul>';
-			foreach ( $yoimg_search_providers as $yoimg_search_provider ) {
-				print '<li><a href="' . $yoimg_search_provider['url'] . '" target="_blank">' . $yoimg_search_provider['name'] . '</a>,';
-				print __('see T&C for more info.', YOIMG_DOMAIN );
-				print '</li>';
+			if ( isset( $yoimg_search_providers ) && ! empty( $yoimg_search_providers ) && is_array( $yoimg_search_providers ) ) {
+				print '<br /><br />';
+				print __('Images sources:', YOIMG_DOMAIN );
+				print '<ul>';
+				foreach ( $yoimg_search_providers as $yoimg_search_provider ) {
+					print '<li><a href="' . $yoimg_search_provider['url'] . '" target="_blank">' . $yoimg_search_provider['name'] . '</a>,';
+					print __('see T&C for more info.', YOIMG_DOMAIN );
+					print '</li>';
+				}
+				print '</ul>';
 			}
-			print '</ul>';
 		}
 		
 		public function cropping_is_active_callback() {


### PR DESCRIPTION
Hi,

You should repair $yoimg_search_providers variable, as at the moment `foreach` array on line 131 in **settings.php** trying to loop unexisted variable (as there are nothing due variable is defined in **init.php** only if module is enabled).

Having disabled module results in `Warning: Invalid argument supplied for foreach() in [...]\wp-content\plugins\yoimages\vendor\sirulli\yoimages-commons\inc\settings.php on line 131`.

Solution is to check if $yoimg_search_providers variable is set, is not empty and is array.

Greetings
