### PR TITLE
Fix for accessing function's array in PHP < 5.4

### DIFF
--- a/inc/init.php
+++ b/inc/init.php
@@ -40,8 +40,10 @@ if ( ! defined( 'YOIMG_COMMONS_PATH' ) ) {
 
 	function filter_yoimg_meta( $links, $file ) {
 		global $yoimg_modules;
-		$file_base_dir = explode( '/', plugin_dir_path( $file ))[0];
-		$plugin_slug = explode( '/', plugin_basename( YOIMG_COMMONS_PATH ) )[0];
+		$file_base_dir = explode( '/', plugin_dir_path( $file ));
+		$file_base_dir = $file_base_dir[0];
+		$plugin_slug = explode( '/', plugin_basename( YOIMG_COMMONS_PATH ) );
+		$plugin_slug = $plugin_slug[0];
 		$is_yoimg_module_w_settings = isset($yoimg_modules[$file_base_dir]['has-settings']) && $yoimg_modules[$file_base_dir]['has-settings'];
 		if ( $file_base_dir == $plugin_slug || $is_yoimg_module_w_settings ) {
 			$plugin_settings_link = 'options-general.php?page=yoimg-settings';


### PR DESCRIPTION
Hi,

I have one website on subdomain of someone's else (due to domain name) and this server is very poor. Anyways, when I tried active your plugin, I have got **critical error** as in `inc\init.php` is accessing index 0 from array directly from function.

This is allowed from PHP 5.4 as you can see in _Example 7_ on [Arrays manual](http://php.net/manual/en/language.types.array.php). The server seems then to be under version 5.4.

Did just the same variable names, so it's not accessing array directly from function return. After change I activated plugin successfully.

Greetings
